### PR TITLE
Default config in plugin Code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,10 +54,18 @@ module.exports = function EnterpriseProbePlugin () {
    * @param {Boolean} isDummy - dummy-mode flag
    * @returns {Promise}
    */
-  this.init = function (config, context, isDummy) {
-    if (!config || _.isEmpty(config)) {
-      throw new Error('plugin-probe: no configuration provided.');
-    }
+  this.init = function (customConfig, context, isDummy) {
+    let defaultConfig = {
+      'threads': 1,
+      'loadedBy': 'server',
+      'maxMemoryRestart': '1G',
+      'databases': [
+        'localhost:9200'
+      ],
+      'storageIndex': 'measures',
+      'probes': {}
+    };
+    let config = Object.assign(defaultConfig, customConfig);
 
     if (!config.databases || !Array.isArray(config.databases) || !config.databases.length) {
       throw new Error('plugin-probe: no target database set');

--- a/package.json
+++ b/package.json
@@ -25,18 +25,6 @@
   "bugs": {
     "url": "https://github.com/kuzzleio/kuzzle-enterprise-probe/issues"
   },
-  "pluginInfo": {
-    "defaultConfig": {
-      "threads": 1,
-      "loadedBy": "server",
-      "maxMemoryRestart": "1G",
-      "databases": [
-        "localhost:9200"
-      ],
-      "storageIndex": "measures",
-      "probes": {}
-    }
-  },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "bluebird": "^3.4.6",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,20 +46,12 @@ describe('#Testing index file', () => {
     setIntervalSpy.restore();
   });
 
-  it('should throw an error if no config is provided', () => {
-    should(() => plugin.init({}, {}, false)).throw(/no configuration provided/);
-    should(() => plugin.init(undefined, {}, false)).throw(/no configuration provided/);
-    should(() => plugin.init(null, {}, false)).throw(/no configuration provided/);
-  });
-
   it('should throw an error if no target database is configured', () => {
-    should(() => plugin.init({foo: 'bar'}, {}, false)).throw(/no target database set/);
     should(() => plugin.init({databases: 'foo:bar'}, {}, false)).throw(/no target database set/);
     should(() => plugin.init({databases: []}, {}, false)).throw(/no target database set/);
   });
 
   it('should throw an error if no storage index is configured', () => {
-    should(() => plugin.init({databases: ['foo:bar']}, {}, false)).throw(/no storage index/);
     should(() => plugin.init({databases: ['foo:bar'], storageIndex: 1}, {}, false)).throw(/no storage index/);
     should(() => plugin.init({databases: ['foo:bar'], storageIndex: ''}, {}, false)).throw(/no storage index/);
   });


### PR DESCRIPTION
Adapts the plugin to the Apache-ish installation system specified in kuzzleio/kuzzle#609

The plugin has now its own default config in its own code and can run with a null customConfig passed to the init function.